### PR TITLE
Add support for multiple calendars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-events_ts.json
+events_ts_*.json
 config.py
 credentials/*
 !credentials/quickstart.py

--- a/config_sample.py
+++ b/config_sample.py
@@ -9,9 +9,14 @@ future_days = 365  # retrieve this many future days of events
 
 # google
 google_token_path = "./credentials/google_token.pickle"
-google_calendar_id = "your-calendar-id-here@group.calendar.google.com"
+
+# calendars
+calendars = [
+	["You Outlook Calendar Name Here", "your-calendar-id-here@group.calendar.google.com"]
+]
+
 
 # misc
-events_ts_json_path = "./events_ts.json"
+events_ts_json_path = "./events_ts_{0}.json"
 pause = 0.1
 force = False  # force full run even if no changes


### PR DESCRIPTION
Allows to sync multiple calendars using a list of Outlook calendar name + Google calendar ID pairs instead of the default Outlook calendar and a single Google calendar ID.